### PR TITLE
setup untracked absolute path env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sonic-pi

--- a/test.rb
+++ b/test.rb
@@ -1,6 +1,6 @@
 # Welcome to Sonic Pi v3.1
 #
-path='C:\Users\Mantas\Desktop\SONIC_PI'
+path=get(:rfpath)
 #chage path to local project folder
 
 while (true)
@@ -26,7 +26,7 @@ while (true)
   sleep 1
   play chord(:D,:major)
   sleep 0.3
-  run_file path+'\splurge.rb'
+  run_file path+'splurge.rb'
   sleep 0.7
   
 end

--- a/test.rb
+++ b/test.rb
@@ -1,7 +1,8 @@
-# Welcome to Sonic Pi v3.1
+# Set :rfpath var in `./.sonic-pi/init.rb` by adding this line:
+# `set :rfpath, "path/to/this/dir"`
 #
+# More details: https://in-thread.sonic-pi.net/t/relative-paths-for-run-file/804/2
 path=get(:rfpath)
-#chage path to local project folder
 
 while (true)
   


### PR DESCRIPTION
Pasetupinau dir path variable taip kad nereikėtų kiekvienąkart keitelioti ant skirtingų kompų

Pagal šitą komentarą: https://in-thread.sonic-pi.net/t/relative-paths-for-run-file/804


Šiaip neturėtų būti taip sunku, truputį neišbaigtas įrankis šitas Sonic PI.


Dabar tau reikėtų pasetupint failiuką ant savo kompo kad veiktų:
```
# Set :rfpath var in `./.sonic-pi/init.rb` by adding this line:
# `set :rfpath, "path/to/this/dir"`
```